### PR TITLE
Export csv_stream_fun/0 type

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -10,3 +10,4 @@
     {erl_opts, [inline_list_funcs, deterministic]}
    ]}
 ]}.
+{dialyzer, [{warnings, [unknown]}]}.

--- a/src/erl_csv.hrl
+++ b/src/erl_csv.hrl
@@ -16,6 +16,6 @@
 -type csv_stream() :: #csv_stream{} | stream_end.
 -type maybe_csv_stream() :: csv_stream() | {error, term()}.
 -type csv_stream_fun() :: fun(() -> maybe_csv_stream()).
--export_type([csv_stream/0]).
+-export_type([csv_stream/0, csv_stream_fun/0]).
 
 -endif.


### PR DESCRIPTION
and enable unknown types/functions dialyzer warnings.

Fixes:
```
_build/default/lib/erl_csv/src/erl_csv.hrl
Line 12 Column 43: Unknown type erl_csv:csv_stream_fun/0
```